### PR TITLE
fix: windows install script - get.ps1

### DIFF
--- a/get.ps1
+++ b/get.ps1
@@ -54,7 +54,7 @@ function Install-FileManager {
 		if ((Get-Command "pandoc.exe" -ErrorAction SilentlyContinue) -eq $null) { 
 			$path = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).Path
 			$path = $path + ";$folder"
-			Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH –Value $path
+			Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value "$path"
 		}
 
 	Write-Host "filemanager successfully installed!" -ForegroundColor Green 


### PR DESCRIPTION
Retyped "-" before Value and added quotation marks for "$path" (https://github.com/filebrowser/filebrowser/issues/718). This should fix the error showing during path addition process in Windows' Environment Variables.